### PR TITLE
Add endpoint to get total likes

### DIFF
--- a/main_site/server.py
+++ b/main_site/server.py
@@ -797,6 +797,17 @@ def like_product(product_id):
     conn.close()
     return jsonify({'status': 'success', 'likes': new_count})
 
+# جديد: مسار يعيد إجمالي عدد الإعجابات لكل المنتجات
+@app.route('/likes-total', methods=['GET'])
+def get_total_likes():
+    conn = sqlite3.connect('likes.db')
+    cursor = conn.cursor()
+    cursor.execute('SELECT SUM(count) FROM likes')
+    row = cursor.fetchone()
+    conn.close()
+    total = row[0] if row and row[0] is not None else 0
+    return jsonify({'total_likes': total})
+
 
 
 @app.route('/notifications/<user_id>')


### PR DESCRIPTION
## Summary
- extend server with `/likes-total` endpoint that sums likes for all products

## Testing
- `python3 -m py_compile main_site/server.py`

------
https://chatgpt.com/codex/tasks/task_e_68711d3497948326b71d3872541a6e96