### PR TITLE
Fix footer path in TiktokViewer

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome banner', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const bannerElement = screen.getByText(/مرحباً/i);
+  expect(bannerElement).toBeInTheDocument();
 });

--- a/src/components/TiktokViewer.js
+++ b/src/components/TiktokViewer.js
@@ -334,8 +334,9 @@ const FooterLoader = () => {
   const [html, setHtml] = useState("");
 
   useEffect(() => {
-    fetch("/react-tiktok/static/components/footer.html?v=" + Date.now())
-
+    fetch(
+      `${process.env.PUBLIC_URL}/static/components/footer.html?v=` + Date.now()
+    )
       .then((res) => res.text())
       .then((data) => setHtml(data));
   }, []);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,15 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill IntersectionObserver for Jest environment
+class MockIntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!window.IntersectionObserver) {
+  window.IntersectionObserver = MockIntersectionObserver;
+}


### PR DESCRIPTION
## Summary
- update FooterLoader to use `PUBLIC_URL` so footer works in dev and production
- patch tests with a welcome banner check
- polyfill `IntersectionObserver` for Jest

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68722ae252148326b41db6e8f2a1a710